### PR TITLE
ci: refine “CI OK” job checks to account cancelled jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,11 +65,13 @@ jobs:
     needs: [test, check]
     env:
       FAILURE: ${{ contains(join(needs.*.result, ','), 'failure') }}
+      CANCELLED: ${{ contains(join(needs.*.result, ','), 'cancelled') }}
     steps:
-      - name: Check for failure
+      - name: Check for failure or cancelled jobs result
+        shell: bash
         run: |
-          echo $FAILURE
-          if [ "$FAILURE" = "false" ]; then
+          echo "Failure: $FAILURE - Cancelled: $CANCELLED"
+          if [ "$FAILURE" = "false" ] && [ "$CANCELLED" = "false" ]; then
             exit 0
           else
             exit 1


### PR DESCRIPTION
Account for job `result` `cancelled` value in "CI OK" job.
According to the [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#needs-context) possible values are:
- `success`
- `failure`
- `cancelled`
- `skipped`

---

## Example

[Action run link reference](https://github.com/marcalexiei/eslint-config/actions/runs/11718204186/job/32639232139)

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/7594e529-928b-428f-ac60-33c43beeedf6">

As you can see "Test (Node 23)" has been cancelled but "CI OK" report that all test have passed.
Since some of the required checks have been cancelled these should not happen.

> [!NOTE]
> I think that check `skipped` result should not be necessary:
> "CI-OK" won't run if one of `needs` jobs has been skipped.
